### PR TITLE
Change Swift minimum requirement from 5.2 to 5.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
This package doesn't actually require Swift 5.2 (it builds and runs fine with Swift 5.1 except for the `swift-tools-version:5.2` declaration in `Package.swift`) -- this pull request enables pulling in and building swift-mqtt on systems that don't have Swift 5.2.x or 5.3.x available, such as the Raspberry Pi 2.