### PR TITLE
Wait until channel read completes before decoding packet.

### DIFF
--- a/Sources/MQTT/MQTTChannelHandler.swift
+++ b/Sources/MQTT/MQTTChannelHandler.swift
@@ -19,7 +19,9 @@ final class MQTTChannelHandler: ChannelInboundHandler {
         self.decoder = decoder
     }
 
-    func channelRead(context _: ChannelHandlerContext, data: NIOAny) {
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+		defer { context.fireChannelRead(data) }
+
         var buf = unwrapInboundIn(data)
         if let bytes = buf.readBytes(length: buf.readableBytes) {
 			packetData.append(contentsOf: bytes)
@@ -27,6 +29,8 @@ final class MQTTChannelHandler: ChannelInboundHandler {
     }
 
 	func channelReadComplete(context: ChannelHandlerContext) {
+		defer { context.fireChannelReadComplete() }
+
 		var data = packetData
 		packetData = Data()
 
@@ -42,10 +46,12 @@ final class MQTTChannelHandler: ChannelInboundHandler {
 	}
 
     func channelActive(context: ChannelHandlerContext) {
+		defer { context.fireChannelActive() }
         delegate?.channelActive(channel: context.channel)
     }
 
-    func channelInactive(context _: ChannelHandlerContext) {
+    func channelInactive(context: ChannelHandlerContext) {
+		defer { context.fireChannelInactive() }
         delegate?.channelInactive()
     }
 }

--- a/Sources/MQTT/MQTTChannelHandler.swift
+++ b/Sources/MQTT/MQTTChannelHandler.swift
@@ -13,45 +13,45 @@ final class MQTTChannelHandler: ChannelInboundHandler {
 
     private let decoder: MQTTDecoder
     weak var delegate: MQTTChannelHandlerDelegate?
-	private var packetData = Data()
+    private var packetData = Data()
 
     init(decoder: MQTTDecoder = MQTTDecoder()) {
         self.decoder = decoder
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-		defer { context.fireChannelRead(data) }
+        defer { context.fireChannelRead(data) }
 
         var buf = unwrapInboundIn(data)
         if let bytes = buf.readBytes(length: buf.readableBytes) {
-			packetData.append(contentsOf: bytes)
+            packetData.append(contentsOf: bytes)
         }
     }
 
-	func channelReadComplete(context: ChannelHandlerContext) {
-		defer { context.fireChannelReadComplete() }
+    func channelReadComplete(context: ChannelHandlerContext) {
+        defer { context.fireChannelReadComplete() }
 
-		var data = packetData
-		packetData = Data()
+        var data = packetData
+        packetData = Data()
 
-		do {
-			let packet = try decoder.decode(data: &data)
-			delegate?.didReceive(packet: packet)
-		} catch let error as DecodeError {
-			delegate?.didCatch(decodeError: error)
-		} catch {
-			// unhandled error
-			fatalError("Error while decoding packet data: \(error.localizedDescription)")
-		}
-	}
+        do {
+            let packet = try decoder.decode(data: &data)
+            delegate?.didReceive(packet: packet)
+        } catch let error as DecodeError {
+            delegate?.didCatch(decodeError: error)
+        } catch {
+            // unhandled error
+            fatalError("Error while decoding packet data: \(error.localizedDescription)")
+        }
+    }
 
     func channelActive(context: ChannelHandlerContext) {
-		defer { context.fireChannelActive() }
+        defer { context.fireChannelActive() }
         delegate?.channelActive(channel: context.channel)
     }
 
     func channelInactive(context: ChannelHandlerContext) {
-		defer { context.fireChannelInactive() }
+        defer { context.fireChannelInactive() }
         delegate?.channelInactive()
     }
 }


### PR DESCRIPTION
When reading large(ish) amounts of data, it is possible this data is read in multiple passes.
This means that `channelRead` could be called multiple times in succession, each time receiving only a chunk of the full data.

To prevent trying to decode partial data, we must postpone the packet decoding until the channel read operation completes, which is we should do this in `channelReadComplete` instead.

I have also inserted calls to forward operations to the next handler in the pipeline, as suggested by the documentation of the protocol functions.